### PR TITLE
Clean up processes so they don't hang GitLab CI builds

### DIFF
--- a/src/bin/dockerd-entrypoint.sh
+++ b/src/bin/dockerd-entrypoint.sh
@@ -1,6 +1,31 @@
 #!/bin/bash
 
+if [ -z "$1" ]; then
+  echo Command required.
+  exit 1
+fi
+
 supervisord -c /usr/local/etc/supervisor.conf &
+SUPERVISOR_PID=$!
+
+PROCESS_PID=
+
+on_exit() {
+  exit_code=$1
+  if [ -n "${PROCESS_PID}" ]; then
+    kill -TERM ${PROCESS_PID}
+    wait ${PROCESS_PID}
+    PROCESS_PID=
+  fi
+  if [ -n "${SUPERVISOR_PID}" ]; then
+    kill -TERM ${SUPERVISOR_PID}
+    wait ${SUPERVISOR_PID}
+    SUPERVISOR_PID=
+  fi
+  exit $exit_code
+}
+trap 'on_exit 0' EXIT
+trap 'on_exit 1' TERM INT
 
 is_docker_up() {
   curl --unix-socket /var/run/docker.sock -o /dev/null --silent --fail http://docker/_ping
@@ -19,4 +44,9 @@ if ! is_docker_up; then
   exit 1
 fi
 
-exec "$@"
+"$@" &
+PROCESS_PID=$!
+wait $PROCESS_PID
+exit_code=$?
+PROCESS_PID=
+on_exit $exit_code


### PR DESCRIPTION
This solution ensures under any circumstances of termination that a TERM signal is sent to all subprocesses, both the supervisor daemon and the actual process of the command that should be executed with Docker available.